### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ brew install jesseduffield/lazynpm/lazynpm
 ### Go
 
 ```sh
-go get github.com/jesseduffield/lazynpm
+go install github.com/jesseduffield/lazynpm@latest
 ```
 
 Please note:


### PR DESCRIPTION
> ❯ go get github.com/jesseduffield/lazynpm
> go: go.mod file not found in current directory or any parent directory.
> 	'go get' is no longer supported outside a module.
> 	To build and install a command, use 'go install' with a version,
> 	like 'go install example.com/cmd@latest'
> 	For more information, see https://golang.org/doc/go-get-install-deprecation
> 	or run 'go help get' or 'go help install'.